### PR TITLE
Update library to support Rails 5.1.3

### DIFF
--- a/lib/heritage/active_record/acts_as_predecessor.rb
+++ b/lib/heritage/active_record/acts_as_predecessor.rb
@@ -14,9 +14,9 @@ module Heritage
         class_attribute :_acts_as_predecessor_settings
         self._acts_as_predecessor_settings = options
 
-        belongs_to :heir, :polymorphic => true
+        belongs_to :heir, polymorphic: true, optional: true
 
-        before_update :touch_heir, :unless => lambda { heir.changed? }
+        before_update :touch_heir, unless: lambda { heir.changed? }
       end
 
       module ClassMethods


### PR DESCRIPTION
* Add alias_method_chain method in, but scope it to only this module

* Allow belongs_to relationship to be optional

* Update regex to work with rails 5 primary_key indicator